### PR TITLE
Enhance widget variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Install via contao manager or composer:
 
 1. Now you can just create a twig template like `ce_text_custom.html.twig` and add it to your projekt `template` folder (in contao 4.4: `app/Resources/views`) and you can select the template as custom Template in the text content element. You can override every core template that is parsed by `parseTemplate` and `parseWidget` hook.  You can also add templates from bundles.
 
+### Widgets
+
+As already written, this bundle also allows to override widget templates. Since twig templates are not rendered in the default widget/template scope as contao templates, you can't use `$this` to get variables. Instead twig support bundles passes the widget instance so you can use the widget object to get the variable content instand of this, for examle `{{ widget.name }}` or `{{ widget.class }}`. 
+
 ### Twig and contao cavets
 
 User input is encoded by contao, so you need to add the raw filter to variables if you need to output html.

--- a/src/EventListener/RenderListener.php
+++ b/src/EventListener/RenderListener.php
@@ -196,18 +196,22 @@ class RenderListener
 
         $twigTemplatePath = $this->templateLocator->getTemplatePath($twigTemplateName);
 
-        $twigTemplateData['id'] = $twigTemplateData['id'] ?? ($twigTemplateData['strId'] ?? null);
-        $twigTemplateData['name'] = $twigTemplateData['name'] ?? ($twigTemplateData['strName'] ?? null);
-        $twigTemplateData['label'] = $twigTemplateData['label'] ?? ($twigTemplateData['strLabel'] ?? null);
-        $twigTemplateData['description'] = $twigTemplateData['description'] ?? ($twigTemplateData['arrConfiguration']['description'] ?? null);
-        $twigTemplateData['value'] = $twigTemplateData['value'] ?? ($twigTemplateData['varValue'] ?? null);
-        $twigTemplateData['class'] = $twigTemplateData['class'] ?? ($twigTemplateData['strClass'] ?? null);
-        $twigTemplateData['prefix'] = $twigTemplateData['prefix'] ?? ($twigTemplateData['strPrefix'] ?? null);
+        if ($contaoTemplate instanceof Widget) {
+            $twigTemplateData['id'] = $twigTemplateData['id'] ?? ($twigTemplateData['strId'] ?? null);
+            $twigTemplateData['name'] = $twigTemplateData['name'] ?? ($twigTemplateData['strName'] ?? null);
+            $twigTemplateData['label'] = $twigTemplateData['label'] ?? ($twigTemplateData['strLabel'] ?? null);
+            $twigTemplateData['description'] = $twigTemplateData['description'] ?? ($twigTemplateData['arrConfiguration']['description'] ?? null);
+            $twigTemplateData['value'] = $twigTemplateData['value'] ?? ($twigTemplateData['varValue'] ?? null);
+            $twigTemplateData['class'] = $twigTemplateData['class'] ?? ($twigTemplateData['strClass'] ?? null);
+            $twigTemplateData['prefix'] = $twigTemplateData['prefix'] ?? ($twigTemplateData['strPrefix'] ?? null);
 
-        $twigTemplateData['template'] = $twigTemplateData['template'] ?? ($twigTemplateData['strTemplate'] ?? null);
-        $twigTemplateData['wizard'] = $twigTemplateData['wizard'] ?? ($twigTemplateData['strWizard'] ?? null);
-        $twigTemplateData['required'] = $twigTemplateData['required'] ?? ($twigTemplateData['arrConfiguration']['required'] ?? null);
-        $twigTemplateData['forAttribute'] = $twigTemplateData['forAttribute'] ?? ($twigTemplateData['blnForAttribute'] ?? null);
+            $twigTemplateData['template'] = $twigTemplateData['template'] ?? ($twigTemplateData['strTemplate'] ?? null);
+            $twigTemplateData['wizard'] = $twigTemplateData['wizard'] ?? ($twigTemplateData['strWizard'] ?? null);
+            $twigTemplateData['required'] = $twigTemplateData['required'] ?? ($twigTemplateData['arrConfiguration']['required'] ?? null);
+            $twigTemplateData['forAttribute'] = $twigTemplateData['forAttribute'] ?? ($twigTemplateData['blnForAttribute'] ?? null);
+
+            $twigTemplateData['widget'] = $contaoTemplate;
+        }
 
         /** @var BeforeRenderTwigTemplateEvent $event */
         /** @noinspection PhpMethodParametersCountMismatchInspection */

--- a/src/EventListener/RenderListener.php
+++ b/src/EventListener/RenderListener.php
@@ -46,10 +46,6 @@ class RenderListener
      */
     protected $twig;
     /**
-     * @var string
-     */
-    protected $env;
-    /**
      * @var KernelInterface
      */
     protected $kernel;
@@ -77,13 +73,11 @@ class RenderListener
     /**
      * RenderListener constructor.
      */
-    public function __construct(TwigTemplateLocator $templateLocator, string $rootDir, EventDispatcherInterface $eventDispatcher, Environment $twig, string $env, RequestStack $requestStack, ScopeMatcher $scopeMatcher, NormalizerHelper $normalizer, array $bundleConfig)
+    public function __construct(TwigTemplateLocator $templateLocator, EventDispatcherInterface $eventDispatcher, Environment $twig, RequestStack $requestStack, ScopeMatcher $scopeMatcher, NormalizerHelper $normalizer, array $bundleConfig)
     {
         $this->templateLocator = $templateLocator;
-        $this->rootDir = $rootDir;
         $this->eventDispatcher = $eventDispatcher;
         $this->twig = $twig;
-        $this->env = $env;
         $this->requestStack = $requestStack;
         $this->scopeMatcher = $scopeMatcher;
         $this->normalizer = $normalizer;
@@ -197,19 +191,6 @@ class RenderListener
         $twigTemplatePath = $this->templateLocator->getTemplatePath($twigTemplateName);
 
         if ($contaoTemplate instanceof Widget) {
-            $twigTemplateData['id'] = $twigTemplateData['id'] ?? ($twigTemplateData['strId'] ?? null);
-            $twigTemplateData['name'] = $twigTemplateData['name'] ?? ($twigTemplateData['strName'] ?? null);
-            $twigTemplateData['label'] = $twigTemplateData['label'] ?? ($twigTemplateData['strLabel'] ?? null);
-            $twigTemplateData['description'] = $twigTemplateData['description'] ?? ($twigTemplateData['arrConfiguration']['description'] ?? null);
-            $twigTemplateData['value'] = $twigTemplateData['value'] ?? ($twigTemplateData['varValue'] ?? null);
-            $twigTemplateData['class'] = $twigTemplateData['class'] ?? ($twigTemplateData['strClass'] ?? null);
-            $twigTemplateData['prefix'] = $twigTemplateData['prefix'] ?? ($twigTemplateData['strPrefix'] ?? null);
-
-            $twigTemplateData['template'] = $twigTemplateData['template'] ?? ($twigTemplateData['strTemplate'] ?? null);
-            $twigTemplateData['wizard'] = $twigTemplateData['wizard'] ?? ($twigTemplateData['strWizard'] ?? null);
-            $twigTemplateData['required'] = $twigTemplateData['required'] ?? ($twigTemplateData['arrConfiguration']['required'] ?? null);
-            $twigTemplateData['forAttribute'] = $twigTemplateData['forAttribute'] ?? ($twigTemplateData['blnForAttribute'] ?? null);
-
             $twigTemplateData['widget'] = $contaoTemplate;
         }
 

--- a/src/EventListener/RenderListener.php
+++ b/src/EventListener/RenderListener.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright (c) 2020 Heimrich & Hannot GmbH
+ * Copyright (c) 2021 Heimrich & Hannot GmbH
  *
  * @license LGPL-3.0-or-later
  */
@@ -195,6 +195,19 @@ class RenderListener
         $twigTemplateData = $contaoTemplate->{static::TWIG_CONTEXT};
 
         $twigTemplatePath = $this->templateLocator->getTemplatePath($twigTemplateName);
+
+        $twigTemplateData['id'] = $twigTemplateData['id'] ?? ($twigTemplateData['strId'] ?? null);
+        $twigTemplateData['name'] = $twigTemplateData['name'] ?? ($twigTemplateData['strName'] ?? null);
+        $twigTemplateData['label'] = $twigTemplateData['label'] ?? ($twigTemplateData['strLabel'] ?? null);
+        $twigTemplateData['description'] = $twigTemplateData['description'] ?? ($twigTemplateData['arrConfiguration']['description'] ?? null);
+        $twigTemplateData['value'] = $twigTemplateData['value'] ?? ($twigTemplateData['varValue'] ?? null);
+        $twigTemplateData['class'] = $twigTemplateData['class'] ?? ($twigTemplateData['strClass'] ?? null);
+        $twigTemplateData['prefix'] = $twigTemplateData['prefix'] ?? ($twigTemplateData['strPrefix'] ?? null);
+
+        $twigTemplateData['template'] = $twigTemplateData['template'] ?? ($twigTemplateData['strTemplate'] ?? null);
+        $twigTemplateData['wizard'] = $twigTemplateData['wizard'] ?? ($twigTemplateData['strWizard'] ?? null);
+        $twigTemplateData['required'] = $twigTemplateData['required'] ?? ($twigTemplateData['arrConfiguration']['required'] ?? null);
+        $twigTemplateData['forAttribute'] = $twigTemplateData['forAttribute'] ?? ($twigTemplateData['blnForAttribute'] ?? null);
 
         /** @var BeforeRenderTwigTemplateEvent $event */
         /** @noinspection PhpMethodParametersCountMismatchInspection */

--- a/tests/EventListener/RenderListenerTest.php
+++ b/tests/EventListener/RenderListenerTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * Copyright (c) 2021 Heimrich & Hannot GmbH
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace HeimrichHannot\TwigSupportBundle\Test\EventListener;
+
+use Contao\CoreBundle\Routing\ScopeMatcher;
+use Contao\FrontendTemplate;
+use Contao\TestCase\ContaoTestCase;
+use Contao\Widget;
+use HeimrichHannot\TwigSupportBundle\EventListener\RenderListener;
+use HeimrichHannot\TwigSupportBundle\Filesystem\TwigTemplateLocator;
+use HeimrichHannot\TwigSupportBundle\Helper\NormalizerHelper;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Twig\Environment;
+
+class RenderListenerTest extends ContaoTestCase
+{
+    public function createTestInstance(array $parameters = [])
+    {
+        if (!isset($parameters['templateLocator'])) {
+            $templateLocator = $this->createMock(TwigTemplateLocator::class);
+            $templateLocator->method('getTemplatePath')->willReturnArgument(0);
+            $parameters['templateLocator'] = $templateLocator;
+        }
+
+        if (!isset($parameters['eventDispatcher'])) {
+            $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+            $eventDispatcher->method('dispatch')->willReturnArgument(1);
+            $parameters['eventDispatcher'] = $eventDispatcher;
+        }
+
+        if (!isset($parameters['twig'])) {
+            $twig = $this->createMock(Environment::class);
+            $twig->method('render')->willReturnArgument(0);
+            $parameters['twig'] = $twig;
+        }
+
+        if (!isset($parameters['requestStack'])) {
+            $parameters['requestStack'] = $this->createMock(RequestStack::class);
+        }
+
+        if (!isset($parameters['scopeMatcher'])) {
+            $parameters['scopeMatcher'] = $this->createMock(ScopeMatcher::class);
+        }
+
+        if (!isset($parameters['normalizer'])) {
+            $parameters['normalizer'] = $this->createMock(NormalizerHelper::class);
+        }
+
+        if (!isset($parameters['bundleConfig'])) {
+            $parameters['bundleConfig'] = [];
+        }
+
+        $instance = new RenderListener(
+            $parameters['templateLocator'],
+            $parameters['eventDispatcher'],
+            $parameters['twig'],
+            $parameters['requestStack'],
+            $parameters['scopeMatcher'],
+            $parameters['normalizer'],
+            $parameters['bundleConfig']
+        );
+
+        return $instance;
+    }
+
+    public function testRender()
+    {
+        $twig = $this->createMock(Environment::class);
+        $twig->method('render')->willReturnCallback(function ($template, $data) {
+            TestCase::assertArrayHasKey('widget', $data);
+
+            return $template;
+        });
+        $contaoTemplate = $this->mockClassWithProperties(Widget::class, [
+            RenderListener::TWIG_TEMPLATE => 'widget_template',
+            RenderListener::TWIG_CONTEXT => [],
+        ]);
+        $instance = $this->createTestInstance([
+            'twig' => $twig,
+        ]);
+        $instance->render($contaoTemplate);
+
+        $twig = $this->createMock(Environment::class);
+        $twig->method('render')->willReturnCallback(function ($template, $data) {
+            TestCase::assertArrayNotHasKey('widget', $data);
+
+            return $template;
+        });
+        $contaoTemplate = $this->mockClassWithProperties(FrontendTemplate::class, [
+            RenderListener::TWIG_TEMPLATE => 'widget_template',
+            RenderListener::TWIG_CONTEXT => [],
+        ]);
+        $instance = $this->createTestInstance([
+            'twig' => $twig,
+        ]);
+        $instance->render($contaoTemplate);
+    }
+}


### PR DESCRIPTION
This PR aims to improve the widget handling by adding the default variables known from contao widget templates.

I see two possiblities:
1. Set the variabes in the render method-> advanteage: variables direct usable like `{{ description }} ``. Disadvantage: we not have all variables and some form types overrides getters from widget class. See https://github.com/contao/contao/blob/2ab244e7362b463b8b2caa15953934a4a67d8475/core-bundle/src/Resources/contao/forms/FormTextField.php#L111 vs. https://github.com/contao/contao/blob/2ab244e7362b463b8b2caa15953934a4a67d8475/core-bundle/src/Resources/contao/library/Contao/Widget.php#L387
2. Pass the widget object. So values are are fetched like `{{ widet.value }}`. This has the advantage to have all possible variables available includes the custom changes made by the getter. I don't really see any disadvantage. 

In this PR I currently have added both variants.

What to you think @Defcon0 ?