### PR TITLE
Add twig renderer class

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,30 @@ BeforeRenderTwigTemplate | Dispatched before twig templates is rendered.
 
 ### Use twig in your bundle
 
-This bundle is a great base if you want to use twig in your own bundles. Use the `HeimrichHannot\TwigSupportBundle\Filesystem\TwigTemplateLocator` service to load your templates, where you need them while keeping the contao template hierarchy (you can override a bundle template in your project template folder or in another bundle which is loaded after the bundle).
+This bundle is a great base if you want to use twig in your own bundles.
+
+#### Template locator
+
+Use the `TwigTemplateLocator` service to load your templates, where you need them while keeping the contao template hierarchy (you can override a bundle template in your project template folder or in another bundle which is loaded after the bundle).
+
+Get all Templates with prefix (like Controller::getTemplateGroup): `TwigTemplateLocator::getTemplateGroup()`
+
+```php
+class CustomContainer
+{
+    /**
+     * @var HeimrichHannot\TwigSupportBundle\Filesystem\TwigTemplateLocator
+     */
+    protected $templateLocator;
+
+    public function onTemplateOptionsCallback()
+    {
+        return $this->templateLocator->getTemplateGroup('subscribe_button_');
+    }
+}
+```
+
+Get the twig path from an template name:
 
 ```php
 use HeimrichHannot\TwigSupportBundle\Filesystem\TwigTemplateLocator;
@@ -78,7 +101,38 @@ function showTemplateLocatorUsage(TwigTemplateLocator $templateLocator, Environm
 }
 ```
 
-There is also a `TwigFrontendTemplate` class which inherits from the contao FrontendTemplate class and can be used to render twig template in contao context and use all hooks and template class functions.
+#### Template renderer
+
+Use the `TwigTemplateRenderer` service to render a template by template name. The renderer adds template comments in dev mode as contao does for html5 templates.  There are additional config options to customize the renderer or render a specific twig template instead of using the template locator to get the correct path to an template name. If you need to add specific logic applied before or after rendering, we recommend to [decorate the service](https://symfony.com/doc/current/service_container/service_decoration.html).
+
+```php
+use HeimrichHannot\TwigSupportBundle\Renderer\TwigTemplateRenderer;
+use HeimrichHannot\TwigSupportBundle\Renderer\TwigTemplateRendererConfiguration;
+
+class MyCustomController {
+
+    /** @var TwigTemplateRenderer */
+    protected $twigTemplateRenderer;
+
+    public function renderAction(string $templateName = 'mod_default', array $templateData = []): string
+    {
+        $buffer = $this->twigTemplateRenderer->render($templateName, $templateData);
+        
+        // Or pass some configuration:
+        
+        $configuration = (new TwigTemplateRendererConfiguration())
+                                ->setShowTemplateComments(false)
+                                ->setTemplatePath('@AcmeBundle/module/mod_custom.html.twig')
+                                ->setThrowExceptionOnError(false);
+                                
+        return $this->twigTemplateRenderer->render($templateName, $templateData, $configuration);
+    }
+}
+```
+
+#### TwigFrontendTemplate
+
+You can use the `TwigFrontendTemplate` class to work with a twig template as it's a normal contao frontend template object. It inherits from the contao FrontendTemplate class and can be used to render twig template in contao context and use all hooks and template class functions.
 
 ```php
 use HeimrichHannot\TwigSupportBundle\Template\TwigFrontendTemplate;

--- a/src/EventListener/RenderListener.php
+++ b/src/EventListener/RenderListener.php
@@ -8,7 +8,6 @@
 
 namespace HeimrichHannot\TwigSupportBundle\EventListener;
 
-use Contao\Config;
 use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\Template;
 use Contao\TemplateLoader;
@@ -18,6 +17,8 @@ use HeimrichHannot\TwigSupportBundle\Event\BeforeRenderTwigTemplateEvent;
 use HeimrichHannot\TwigSupportBundle\Exception\TemplateNotFoundException;
 use HeimrichHannot\TwigSupportBundle\Filesystem\TwigTemplateLocator;
 use HeimrichHannot\TwigSupportBundle\Helper\NormalizerHelper;
+use HeimrichHannot\TwigSupportBundle\Renderer\TwigTemplateRenderer;
+use HeimrichHannot\TwigSupportBundle\Renderer\TwigTemplateRendererConfiguration;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -70,11 +71,15 @@ class RenderListener
      * @var bool
      */
     protected $enableTemplateLoader = false;
+    /**
+     * @var TwigTemplateRenderer
+     */
+    protected $twigTemplateRenderer;
 
     /**
      * RenderListener constructor.
      */
-    public function __construct(TwigTemplateLocator $templateLocator, EventDispatcherInterface $eventDispatcher, Environment $twig, RequestStack $requestStack, ScopeMatcher $scopeMatcher, NormalizerHelper $normalizer, array $bundleConfig)
+    public function __construct(TwigTemplateLocator $templateLocator, EventDispatcherInterface $eventDispatcher, Environment $twig, RequestStack $requestStack, ScopeMatcher $scopeMatcher, NormalizerHelper $normalizer, array $bundleConfig, TwigTemplateRenderer $twigTemplateRenderer)
     {
         $this->templateLocator = $templateLocator;
         $this->eventDispatcher = $eventDispatcher;
@@ -87,6 +92,7 @@ class RenderListener
         if (isset($bundleConfig['enable_template_loader']) && true === $bundleConfig['enable_template_loader']) {
             $this->enableTemplateLoader = true;
         }
+        $this->twigTemplateRenderer = $twigTemplateRenderer;
     }
 
     /**
@@ -172,6 +178,11 @@ class RenderListener
      * Render the template.
      *
      * @param $contaoTemplate
+     *
+     * @throws TemplateNotFoundException
+     * @throws \Twig\Error\LoaderError
+     * @throws \Twig\Error\RuntimeError
+     * @throws \Twig\Error\SyntaxError
      */
     public function render($contaoTemplate): string
     {
@@ -196,14 +207,9 @@ class RenderListener
             $contaoTemplate->setData($event->getTemplateData());
         }
 
-        $buffer = $this->twig->render($event->getTwigTemplatePath(), $event->getTemplateData());
+        $rendererConfiguration = (new TwigTemplateRendererConfiguration())->setTemplatePath($event->getTwigTemplatePath());
 
-        if (Config::get('debugMode')) {
-            $strRelPath = $event->getTwigTemplatePath();
-            $buffer = "\n<!-- TWIG TEMPLATE START: $strRelPath -->\n$buffer\n<!-- TWIG TEMPLATE END: $strRelPath -->\n";
-        }
-
-        return $buffer;
+        return $this->twigTemplateRenderer->render($twigTemplateName, $event->getTemplateData(), $rendererConfiguration);
     }
 
     /**

--- a/src/EventListener/RenderListener.php
+++ b/src/EventListener/RenderListener.php
@@ -22,7 +22,6 @@ use HeimrichHannot\TwigSupportBundle\Renderer\TwigTemplateRendererConfiguration;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\KernelInterface;
-use Twig\Environment;
 
 class RenderListener
 {
@@ -43,10 +42,6 @@ class RenderListener
      * @var EventDispatcherInterface
      */
     protected $eventDispatcher;
-    /**
-     * @var Environment
-     */
-    protected $twig;
     /**
      * @var KernelInterface
      */
@@ -79,20 +74,19 @@ class RenderListener
     /**
      * RenderListener constructor.
      */
-    public function __construct(TwigTemplateLocator $templateLocator, EventDispatcherInterface $eventDispatcher, Environment $twig, RequestStack $requestStack, ScopeMatcher $scopeMatcher, NormalizerHelper $normalizer, array $bundleConfig, TwigTemplateRenderer $twigTemplateRenderer)
+    public function __construct(TwigTemplateLocator $templateLocator, EventDispatcherInterface $eventDispatcher, RequestStack $requestStack, ScopeMatcher $scopeMatcher, NormalizerHelper $normalizer, array $bundleConfig, TwigTemplateRenderer $twigTemplateRenderer)
     {
         $this->templateLocator = $templateLocator;
         $this->eventDispatcher = $eventDispatcher;
-        $this->twig = $twig;
         $this->requestStack = $requestStack;
         $this->scopeMatcher = $scopeMatcher;
         $this->normalizer = $normalizer;
         $this->bundleConfig = $bundleConfig;
+        $this->twigTemplateRenderer = $twigTemplateRenderer;
 
         if (isset($bundleConfig['enable_template_loader']) && true === $bundleConfig['enable_template_loader']) {
             $this->enableTemplateLoader = true;
         }
-        $this->twigTemplateRenderer = $twigTemplateRenderer;
     }
 
     /**

--- a/src/Renderer/TwigTemplateRenderer.php
+++ b/src/Renderer/TwigTemplateRenderer.php
@@ -47,7 +47,7 @@ class TwigTemplateRenderer
 
         $buffer = null;
 
-        if (null !== $configuration->getTemplatePath()) {
+        if (null === $configuration->getTemplatePath()) {
             try {
                 $templatePath = $this->templateLocator->getTemplatePath($templateName);
             } catch (TemplateNotFoundException $e) {

--- a/src/Renderer/TwigTemplateRenderer.php
+++ b/src/Renderer/TwigTemplateRenderer.php
@@ -55,6 +55,7 @@ class TwigTemplateRenderer
                     throw $e;
                 }
                 $buffer = '';
+                $templatePath = 'Template not found: '.$templateName;
             }
         } else {
             $templatePath = $configuration->getTemplatePath();

--- a/src/Renderer/TwigTemplateRenderer.php
+++ b/src/Renderer/TwigTemplateRenderer.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * Copyright (c) 2021 Heimrich & Hannot GmbH
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace HeimrichHannot\TwigSupportBundle\Renderer;
+
+use Contao\Config;
+use Contao\CoreBundle\Framework\ContaoFramework;
+use HeimrichHannot\TwigSupportBundle\Exception\TemplateNotFoundException;
+use HeimrichHannot\TwigSupportBundle\Filesystem\TwigTemplateLocator;
+use Twig\Environment;
+use Twig\Error\LoaderError;
+use Twig\Error\RuntimeError;
+use Twig\Error\SyntaxError;
+
+class TwigTemplateRenderer
+{
+    protected $twig;
+    protected $templateLocator;
+    protected $contaoFramework;
+
+    /**
+     * TwigTemplateRenderer constructor.
+     */
+    public function __construct(Environment $twig, TwigTemplateLocator $templateLocator, ContaoFramework $contaoFramework)
+    {
+        $this->twig = $twig;
+        $this->templateLocator = $templateLocator;
+        $this->contaoFramework = $contaoFramework;
+    }
+
+    /**
+     * @throws \HeimrichHannot\TwigSupportBundle\Exception\TemplateNotFoundException
+     * @throws \Twig\Error\LoaderError
+     * @throws \Twig\Error\RuntimeError
+     * @throws \Twig\Error\SyntaxError                                               Configuration
+     */
+    public function render(string $templateName, array $templateData = [], ?TwigTemplateRendererConfiguration $configuration = null): string
+    {
+        if (!$configuration) {
+            $configuration = new TwigTemplateRendererConfiguration();
+        }
+
+        $buffer = null;
+
+        if (null !== $configuration->getTemplatePath()) {
+            try {
+                $templatePath = $this->templateLocator->getTemplatePath($templateName);
+            } catch (TemplateNotFoundException $e) {
+                if ($configuration->getThrowExceptionOnError()) {
+                    throw $e;
+                }
+                $buffer = '';
+            }
+        } else {
+            $templatePath = $configuration->getTemplatePath();
+        }
+
+        if (null === $buffer) {
+            try {
+                $buffer = $this->twig->render($templatePath, $templateData);
+            } catch (LoaderError | RuntimeError | SyntaxError $e) {
+                if ($configuration->getThrowExceptionOnError()) {
+                    throw $e;
+                }
+                $buffer = '';
+            }
+        }
+
+        $buffer = $this->addTemplateComments($configuration, $templatePath, $buffer);
+
+        return $buffer;
+    }
+
+    protected function addTemplateComments(?TwigTemplateRendererConfiguration $configuration, string $templatePath, string $buffer): string
+    {
+        if ($configuration->getShowTemplateComments() && $this->contaoFramework->isInitialized() && Config::get('debugMode')) {
+            $buffer = "\n<!-- TWIG TEMPLATE START: $templatePath -->\n$buffer\n<!-- TWIG TEMPLATE END: $templatePath -->\n";
+        }
+
+        return $buffer;
+    }
+}

--- a/src/Renderer/TwigTemplateRendererConfiguration.php
+++ b/src/Renderer/TwigTemplateRendererConfiguration.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * Copyright (c) 2021 Heimrich & Hannot GmbH
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace HeimrichHannot\TwigSupportBundle\Renderer;
+
+class TwigTemplateRendererConfiguration
+{
+    /** @var bool */
+    protected $showTemplateComments = true;
+    /** @var bool */
+    protected $throwExceptionOnError = true;
+    /** @var string|null */
+    protected $templatePath;
+
+    public function getShowTemplateComments(): bool
+    {
+        return $this->showTemplateComments;
+    }
+
+    /**
+     * Set to false if you don't want template comments in dev mode.
+     */
+    public function setShowTemplateComments(bool $showTemplateComments): self
+    {
+        $this->showTemplateComments = $showTemplateComments;
+
+        return $this;
+    }
+
+    public function getThrowExceptionOnError(): bool
+    {
+        return $this->throwExceptionOnError;
+    }
+
+    /**
+     * Set to false if no exception should be thrown when an error occurs.
+     */
+    public function setThrowExceptionOnError(bool $throwExceptionOnError): self
+    {
+        $this->throwExceptionOnError = $throwExceptionOnError;
+
+        return $this;
+    }
+
+    public function getTemplatePath(): ?string
+    {
+        return $this->templatePath;
+    }
+
+    /**
+     * Set a twig template path to override the twig name property and skip the twig template locator template loading step.
+     */
+    public function setTemplatePath(?string $templatePath): self
+    {
+        $this->templatePath = $templatePath;
+
+        return $this;
+    }
+}

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -13,6 +13,9 @@ services:
   HeimrichHannot\TwigSupportBundle\Filesystem\TwigTemplateLocator:
     public: true
   HeimrichHannot\TwigSupportBundle\Helper\NormalizerHelper: ~
+  HeimrichHannot\TwigSupportBundle\Renderer\TwigTemplateRenderer:
+    public: true
+
   huh_twig_support.cache.templates:
     class: Symfony\Component\Cache\Adapter\FilesystemAdapter
     arguments:

--- a/tests/EventListener/RenderListenerTest.php
+++ b/tests/EventListener/RenderListenerTest.php
@@ -15,6 +15,7 @@ use Contao\Widget;
 use HeimrichHannot\TwigSupportBundle\EventListener\RenderListener;
 use HeimrichHannot\TwigSupportBundle\Filesystem\TwigTemplateLocator;
 use HeimrichHannot\TwigSupportBundle\Helper\NormalizerHelper;
+use HeimrichHannot\TwigSupportBundle\Renderer\TwigTemplateRenderer;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -58,14 +59,16 @@ class RenderListenerTest extends ContaoTestCase
             $parameters['bundleConfig'] = [];
         }
 
+        $templateRenderer = $parameters['templateRenderer'] ?? $this->createMock(TwigTemplateRenderer::class);
+
         $instance = new RenderListener(
             $parameters['templateLocator'],
             $parameters['eventDispatcher'],
-            $parameters['twig'],
             $parameters['requestStack'],
             $parameters['scopeMatcher'],
             $parameters['normalizer'],
-            $parameters['bundleConfig']
+            $parameters['bundleConfig'],
+            $templateRenderer
         );
 
         return $instance;
@@ -73,8 +76,8 @@ class RenderListenerTest extends ContaoTestCase
 
     public function testRender()
     {
-        $twig = $this->createMock(Environment::class);
-        $twig->method('render')->willReturnCallback(function ($template, $data) {
+        $templateRenderer = $this->createMock(TwigTemplateRenderer::class);
+        $templateRenderer->method('render')->willReturnCallback(function ($template, $data) {
             TestCase::assertArrayHasKey('widget', $data);
 
             return $template;
@@ -84,12 +87,12 @@ class RenderListenerTest extends ContaoTestCase
             RenderListener::TWIG_CONTEXT => [],
         ]);
         $instance = $this->createTestInstance([
-            'twig' => $twig,
+            'templateRenderer' => $templateRenderer,
         ]);
         $instance->render($contaoTemplate);
 
-        $twig = $this->createMock(Environment::class);
-        $twig->method('render')->willReturnCallback(function ($template, $data) {
+        $templateRenderer = $this->createMock(TwigTemplateRenderer::class);
+        $templateRenderer->method('render')->willReturnCallback(function ($template, $data) {
             TestCase::assertArrayNotHasKey('widget', $data);
 
             return $template;
@@ -99,7 +102,7 @@ class RenderListenerTest extends ContaoTestCase
             RenderListener::TWIG_CONTEXT => [],
         ]);
         $instance = $this->createTestInstance([
-            'twig' => $twig,
+            'templateRenderer' => $templateRenderer,
         ]);
         $instance->render($contaoTemplate);
     }

--- a/tests/Renderer/TwigTemplateRendererTest.php
+++ b/tests/Renderer/TwigTemplateRendererTest.php
@@ -8,10 +8,13 @@
 
 namespace HeimrichHannot\TwigSupportBundle\Test\Renderer;
 
+use Contao\Config;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\TestCase\ContaoTestCase;
+use HeimrichHannot\TwigSupportBundle\Exception\TemplateNotFoundException;
 use HeimrichHannot\TwigSupportBundle\Filesystem\TwigTemplateLocator;
 use HeimrichHannot\TwigSupportBundle\Renderer\TwigTemplateRenderer;
+use HeimrichHannot\TwigSupportBundle\Renderer\TwigTemplateRendererConfiguration;
 use Twig\Environment;
 use Twig\Error\LoaderError;
 
@@ -41,6 +44,17 @@ class TwigTemplateRendererTest extends ContaoTestCase
            }
         });
 
+        $templateLocator = $this->createMock(TwigTemplateLocator::class);
+        $templateLocator->method('getTemplatePath')->willReturnCallback(function ($name) {
+            switch ($name) {
+                case 'none':
+                    throw new TemplateNotFoundException('Not found');
+
+                default:
+                    return $name;
+            }
+        });
+
         $instance = $this->createTestInstance([
             'twig' => $twig,
         ]);
@@ -54,14 +68,40 @@ class TwigTemplateRendererTest extends ContaoTestCase
         }
         $this->assertTrue($hasError);
 
-        $templateLocator = $this->createMock(TwigTemplateLocator::class);
-        $templateLocator->method('getTemplatePath')->willReturnArgument(0);
+        $configuration = (new TwigTemplateRendererConfiguration())->setShowTemplateComments(false)->setThrowExceptionOnError(false);
+        $this->assertEmpty($instance->render('null', [], $configuration));
 
         $instance = $this->createTestInstance([
             'twig' => $twig,
             'templateLocator' => $templateLocator,
         ]);
 
-        $instance->render('template', []);
+        $hasError = false;
+
+        try {
+            $instance->render('none', []);
+        } catch (TemplateNotFoundException $e) {
+            $hasError = true;
+        }
+        $this->assertTrue($hasError);
+
+        $configuration = (new TwigTemplateRendererConfiguration())->setShowTemplateComments(false)->setThrowExceptionOnError(false);
+        $this->assertEmpty($instance->render('none', [], $configuration));
+
+        $configuration->setTemplatePath('template');
+        $this->assertSame('template', $instance->render('template', [], $configuration));
+
+        $configuration->setShowTemplateComments(true);
+        $this->assertSame('template', $instance->render('template', [], $configuration));
+
+        $framework = $this->createMock(ContaoFramework::class);
+        $framework->method('isInitialized')->willReturn(true);
+        $instance = $this->createTestInstance([
+            'twig' => $twig,
+            'templateLocator' => $templateLocator,
+            'framework' => $framework,
+        ]);
+        Config::set('debugMode', true);
+        $this->assertSame("\n<!-- TWIG TEMPLATE START: template -->\ntemplate\n<!-- TWIG TEMPLATE END: template -->\n", $instance->render('template', [], $configuration));
     }
 }

--- a/tests/Renderer/TwigTemplateRendererTest.php
+++ b/tests/Renderer/TwigTemplateRendererTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * Copyright (c) 2021 Heimrich & Hannot GmbH
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace HeimrichHannot\TwigSupportBundle\Test\Renderer;
+
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\TestCase\ContaoTestCase;
+use HeimrichHannot\TwigSupportBundle\Filesystem\TwigTemplateLocator;
+use HeimrichHannot\TwigSupportBundle\Renderer\TwigTemplateRenderer;
+use Twig\Environment;
+use Twig\Error\LoaderError;
+
+class TwigTemplateRendererTest extends ContaoTestCase
+{
+    public function createTestInstance(array $parameters = [])
+    {
+        $twig = $parameters['twig'] ?? $this->createMock(Environment::class);
+        $templateLocator = $parameters['templateLocator'] ?? $this->createMock(TwigTemplateLocator::class);
+        $framework = $parameters['framework'] ?? $this->createMock(ContaoFramework::class);
+        $instance = new TwigTemplateRenderer($twig, $templateLocator, $framework);
+
+        return $instance;
+    }
+
+    public function testRender()
+    {
+        $twig = $this->createMock(Environment::class);
+        $twig->method('render')->willReturnCallback(function ($name, $data) {
+            switch ($name) {
+               case null:
+               case 'null':
+                   throw new LoaderError('Loader error');
+
+               default:
+                   return $name;
+           }
+        });
+
+        $instance = $this->createTestInstance([
+            'twig' => $twig,
+        ]);
+
+        $hasError = false;
+
+        try {
+            $instance->render('null', []);
+        } catch (LoaderError $e) {
+            $hasError = true;
+        }
+        $this->assertTrue($hasError);
+
+        $templateLocator = $this->createMock(TwigTemplateLocator::class);
+        $templateLocator->method('getTemplatePath')->willReturnArgument(0);
+
+        $instance = $this->createTestInstance([
+            'twig' => $twig,
+            'templateLocator' => $templateLocator,
+        ]);
+
+        $instance->render('template', []);
+    }
+}

--- a/tests/Renderer/TwigTemplateRendererTest.php
+++ b/tests/Renderer/TwigTemplateRendererTest.php
@@ -20,6 +20,11 @@ use Twig\Error\LoaderError;
 
 class TwigTemplateRendererTest extends ContaoTestCase
 {
+    /**
+     * @return TwigTemplateRenderer
+     *
+     * @runInSeparateProcess
+     */
     public function createTestInstance(array $parameters = [])
     {
         $twig = $parameters['twig'] ?? $this->createMock(Environment::class);

--- a/tests/Template/TwigFrontendTemplateTest.php
+++ b/tests/Template/TwigFrontendTemplateTest.php
@@ -15,6 +15,9 @@ use HeimrichHannot\TwigSupportBundle\Template\TwigFrontendTemplate;
 
 class TwigFrontendTemplateTest extends ContaoTestCase
 {
+    /**
+     * @runInSeparateProcess
+     */
     public function testInherit()
     {
         $instance = $this->getMockBuilder(TwigFrontendTemplate::class)->disableOriginalConstructor()->setMethods(null)->getMock();


### PR DESCRIPTION
This PR add a twig renderer class to have an single rendering endpoint and closes the last feature gap I think. 

I explicit didn't add an event, cause service decoration could be used and is the better patter in my opinion.

ToDo:
- [x] Tests